### PR TITLE
feat: set to m4a for higher quality

### DIFF
--- a/src/classes/Cobalt.ts
+++ b/src/classes/Cobalt.ts
@@ -106,7 +106,7 @@ export class Cobalt {
             body: JSON.stringify({
                 url,
                 downloadMode: 'audio',
-                audioFormat: 'mp3',
+                audioFormat: 'm4a',
             }),
         });
 


### PR DESCRIPTION
There has been a notable drop in quality using the new MP3 format.
To try and increase the quality back to the wav format without the speedup bug, we can try using M4A