### PR TITLE
feat: set to opus for higher quality

### DIFF
--- a/src/classes/Cobalt.ts
+++ b/src/classes/Cobalt.ts
@@ -106,7 +106,7 @@ export class Cobalt {
             body: JSON.stringify({
                 url,
                 downloadMode: 'audio',
-                audioFormat: 'mp3',
+                audioFormat: 'm4a',
             }),
         });
 

--- a/src/classes/Cobalt.ts
+++ b/src/classes/Cobalt.ts
@@ -106,7 +106,7 @@ export class Cobalt {
             body: JSON.stringify({
                 url,
                 downloadMode: 'audio',
-                audioFormat: 'm4a',
+                audioFormat: 'opus',
             }),
         });
 

--- a/src/classes/Cobalt.ts
+++ b/src/classes/Cobalt.ts
@@ -107,6 +107,7 @@ export class Cobalt {
                 url,
                 downloadMode: 'audio',
                 audioFormat: 'opus',
+                audioBitrate: '320',
             }),
         });
 


### PR DESCRIPTION
There has been a notable drop in quality using the new MP3 format.
To try and increase the quality without the speedup bug, we can try using opus

With the local cobalt instance there should also be some way to change the bitrate to 320kbps for mp3 but you will have to change that